### PR TITLE
Move all logic to map.js

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,6 @@
     "Store": true,
     "centerLat": true,
     "centerLng": true,
-    "centerZoom": true,
     "pageLoaded": true,
     "countMarkers": true,
     "skel": true,

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -22,7 +22,6 @@ from .utils import now, dottedQuadToNum, get_blacklist
 log = logging.getLogger(__name__)
 compress = Compress()
 
-
 class Pogom(Flask):
 
     def __init__(self, import_name, **kwargs):
@@ -173,9 +172,6 @@ class Pogom(Flask):
 
         map_lat = self.current_location[0]
         map_lng = self.current_location[1]
-        if request.args:
-            map_lat = request.args.get('lat') or self.current_location[0]
-            map_lng = request.args.get('lon') or self.current_location[1]
 
         return render_template('map.html',
                                lat=map_lat,

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -114,8 +114,6 @@ function removePokemonMarker(encounterId) { // eslint-disable-line no-unused-var
 }
 
 function initMap() { // eslint-disable-line no-unused-vars
-    console.log('1')
-    console.log(getParameterByName('zoom'))
     map = new google.maps.Map(document.getElementById('map'), {
         center: {
             lat: Number(getParameterByName('lat')) || centerLat,

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -114,16 +114,14 @@ function removePokemonMarker(encounterId) { // eslint-disable-line no-unused-var
 }
 
 function initMap() { // eslint-disable-line no-unused-vars
-    if (centerZoom) { // checks to see if specified in url
-        Store.set('zoomLevel', centerZoom)
-    }
-
+    console.log('1')
+    console.log(getParameterByName('zoom'))
     map = new google.maps.Map(document.getElementById('map'), {
         center: {
-            lat: centerLat,
-            lng: centerLng
+            lat: Number(getParameterByName('lat')) || centerLat,
+            lng: Number(getParameterByName('lon')) || centerLng
         },
-        zoom: Store.get('zoomLevel'),
+        zoom: Number(getParameterByName('zoom')) || Store.get('zoomLevel'),
         fullscreenControl: true,
         streetViewControl: false,
         mapTypeControl: false,
@@ -1976,6 +1974,23 @@ function toggleGymPokemonDetails(e) { // eslint-disable-line no-unused-vars
     e.lastElementChild.firstElementChild.classList.toggle('fa-angle-double-down')
     e.nextElementSibling.classList.toggle('visible')
 }
+
+function getParameterByName(name, url) {
+    if (!url) {
+        url = window.location.search
+    }
+    name = name.replace(/[[\]]/g, '\\$&')
+    var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)')
+    var results = regex.exec(url)
+    if (!results) {
+        return null
+    }
+    if (!results[2]) {
+        return ''
+    }
+    return decodeURIComponent(results[2].replace(/\+/g, ' '))
+}
+
 
 //
 // Page Ready Exection

--- a/templates/map.html
+++ b/templates/map.html
@@ -421,7 +421,7 @@
     <script src="{{ url_for('static', filename='js/vendor/classie.js').lstrip('/') }}"></script>
     <script>
       var centerLat = {{lat}};
-      var centerLng = {{lng}};	  
+      var centerLng = {{lng}}; 
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
     <script src="{{ url_for('static', filename='dist/js/map.common.min.js').lstrip('/') }}"></script>

--- a/templates/map.html
+++ b/templates/map.html
@@ -420,18 +420,8 @@
     <script src="{{ url_for('static', filename='dist/js/app.min.js').lstrip('/') }}"></script>
     <script src="{{ url_for('static', filename='js/vendor/classie.js').lstrip('/') }}"></script>
     <script>
-        function getParameterByName(name, url) {
-            if (!url) url = window.location.href;
-            name = name.replace(/[\[\]]/g, "\\$&");
-            var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
-                results = regex.exec(url);
-            if (!results) return null;
-            if (!results[2]) return '';
-            return decodeURIComponent(results[2].replace(/\+/g, " "));
-        }
-      var centerLat = {{lat}} || getParameterByName('lat');
-      var centerLng = {{lng}} || getParameterByName('lon');
-      var centerZoom = getParameterByName('zoom');
+      var centerLat = {{lat}};
+      var centerLng = {{lng}};	  
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
     <script src="{{ url_for('static', filename='dist/js/map.common.min.js').lstrip('/') }}"></script>


### PR DESCRIPTION


## Description
I thought it was easiest to PR against your PR that telling you the changes.
The main thing this does is just parse query string in js and avoid all parsing in app.py.
This make it possible to leave the map center marker where it should be and just center the map to the correct coordinates.
Also this avoid storing the zoom when it is set by url, this will keep storing it if the user changes the zoom after the initial load but if he only pans around it will keep the previous stored when it opens the map without params.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
My local test map 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
